### PR TITLE
Handle catalog loading errors

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,12 +1,28 @@
 import json
+import logging
 from pathlib import Path
 
 CATALOG_PATH = Path(__file__).with_name('katalog_web_v2.json')
 
+logger = logging.getLogger(__name__)
+
+
 def load_catalog():
-    """Load the JSON catalog file and return its data."""
-    with CATALOG_PATH.open('r', encoding='utf-8') as f:
-        return json.load(f)
+    """Load the JSON catalog file and return its data.
+
+    Raises:
+        RuntimeError: If the catalog file is missing or contains invalid JSON.
+    """
+    try:
+        with CATALOG_PATH.open('r', encoding='utf-8') as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError as exc:
+                logger.exception("Malformed catalog file: %s", CATALOG_PATH)
+                raise RuntimeError(f"Catalog file {CATALOG_PATH} is malformed") from exc
+    except FileNotFoundError as exc:
+        logger.exception("Catalog file not found: %s", CATALOG_PATH)
+        raise RuntimeError(f"Catalog file {CATALOG_PATH} not found") from exc
 
 def get_chapter_by_code(code: str):
     """Return a chapter dictionary matching the given code.


### PR DESCRIPTION
## Summary
- add logging and robust error handling when loading catalog

## Testing
- `PYTHONPATH=$PWD pytest tests_py/test_backend.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d58d48e0c832bbcc24f941af70de9