### PR TITLE
Cache catalog loads and expose refresh option

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,12 +1,26 @@
 import json
+from functools import lru_cache
 from pathlib import Path
 
 CATALOG_PATH = Path(__file__).with_name('katalog_web_v2.json')
 
-def load_catalog():
-    """Load the JSON catalog file and return its data."""
+@lru_cache(maxsize=1)
+def _load_catalog_from_file():
+    """Internal helper that actually reads the catalog file."""
     with CATALOG_PATH.open('r', encoding='utf-8') as f:
         return json.load(f)
+
+def load_catalog(force_reload: bool = False):
+    """Load the JSON catalog file and return its data.
+
+    Args:
+        force_reload: If ``True`` the cached catalog is discarded and the
+            file is read again. This allows refreshing the cache when the
+            underlying JSON file changes.
+    """
+    if force_reload:
+        _load_catalog_from_file.cache_clear()
+    return _load_catalog_from_file()
 
 def get_chapter_by_code(code: str):
     """Return a chapter dictionary matching the given code.

--- a/tests_py/test_backend.py
+++ b/tests_py/test_backend.py
@@ -1,4 +1,10 @@
 import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import backend
 from backend import load_catalog, get_chapter_by_code
 
 def test_load_catalog_contains_chapters():
@@ -13,3 +19,27 @@ def test_get_chapter_by_code_returns_expected_title():
 def test_get_chapter_by_code_missing_raises():
     with pytest.raises(ValueError):
         get_chapter_by_code('nonexistent')
+
+
+def test_load_catalog_uses_cache(monkeypatch):
+    """Successive calls should not reread the file."""
+    opens = 0
+    from pathlib import Path
+    original_open = Path.open
+
+    def counting_open(self, *args, **kwargs):
+        nonlocal opens
+        if self == backend.CATALOG_PATH:
+            opens += 1
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", counting_open)
+
+    # Ensure cache is empty and first call reads the file
+    load_catalog(force_reload=True)
+    assert opens == 1
+
+    # Subsequent calls should use the cached data
+    load_catalog()
+    get_chapter_by_code('1.1')
+    assert opens == 1


### PR DESCRIPTION
## Summary
- cache catalog JSON loading with an LRU cache and optional refresh flag
- add regression test ensuring repeated loads don't re-read the file

## Testing
- `npm test`
- `pytest tests_py`


------
https://chatgpt.com/codex/tasks/task_e_689d58d5db90832b92c38d5a924b53ee