### PR TITLE
docs: add testing instructions and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # Web-Maint
+
+## Prerequisites
+
+- Python 3 installed.
+- Install dependencies with `pip install -r requirements.txt`.
+- Ensure the `katalog_web_v2.json` file is present in the project root.
+
+## Example Usage
+
+```python
+>>> from backend import load_catalog, get_chapter_by_code
+>>> catalog = load_catalog()
+>>> get_chapter_by_code("1.1")["title"]
+'Linienkenntnisse'
+```
+
+## Testing
+
+Run the test suite to verify functionality:
+
+```bash
+python3 -m pytest -q
+```
+


### PR DESCRIPTION
## Summary
- document prerequisites and JSON catalog requirement
- add example usage of `load_catalog` and `get_chapter_by_code`
- describe running tests with `python3 -m pytest -q`

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d58d8f614832b9db691c2036b91b7