### PR TITLE
Add Flask entrypoint and API tests

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+CATALOG_PATH = Path(__file__).with_name('katalog_web_v2.json')
+
+def load_catalog():
+    """Load the JSON catalog file and return its data."""
+    with CATALOG_PATH.open('r', encoding='utf-8') as f:
+        return json.load(f)
+
+def get_chapter_by_code(code: str):
+    """Return a chapter dictionary matching the given code.
+
+    Raises:
+        ValueError: If no chapter with the code exists.
+    """
+    catalog = load_catalog()
+    for chapter in catalog.get('chapters', []):
+        if chapter.get('code') == code:
+            return chapter
+    raise ValueError(f'chapter {code} not found')

--- a/main.py
+++ b/main.py
@@ -1,0 +1,21 @@
+from flask import Flask, jsonify, abort
+from backend import load_catalog, get_chapter_by_code
+
+app = Flask(__name__)
+
+@app.route('/catalog')
+def catalog():
+    """Return the entire catalog as JSON."""
+    return jsonify(load_catalog())
+
+@app.route('/chapter/<code>')
+def chapter(code):
+    """Return a single chapter by its code."""
+    try:
+        data = get_chapter_by_code(code)
+    except ValueError:
+        abort(404, description=f'chapter {code} not found')
+    return jsonify(data)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+flask

--- a/tests_py/test_backend.py
+++ b/tests_py/test_backend.py
@@ -1,0 +1,15 @@
+import pytest
+from backend import load_catalog, get_chapter_by_code
+
+def test_load_catalog_contains_chapters():
+    data = load_catalog()
+    assert 'chapters' in data
+    assert len(data['chapters']) > 0
+
+def test_get_chapter_by_code_returns_expected_title():
+    chapter = get_chapter_by_code('1.1')
+    assert chapter['title'] == 'Linienkenntnisse'
+
+def test_get_chapter_by_code_missing_raises():
+    with pytest.raises(ValueError):
+        get_chapter_by_code('nonexistent')

--- a/tests_py/test_main.py
+++ b/tests_py/test_main.py
@@ -1,0 +1,22 @@
+from main import app
+
+
+def test_catalog_endpoint():
+    client = app.test_client()
+    resp = client.get('/catalog')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'chapters' in data
+
+
+def test_chapter_endpoint_returns_title():
+    client = app.test_client()
+    resp = client.get('/chapter/1.1')
+    assert resp.status_code == 200
+    assert resp.get_json()['title'] == 'Linienkenntnisse'
+
+
+def test_chapter_endpoint_not_found():
+    client = app.test_client()
+    resp = client.get('/chapter/unknown')
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add `main.py` Flask application serving catalog and chapter endpoints
- test Flask endpoints with `tests_py/test_main.py`
- include Flask in `requirements.txt`

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d56c59910832bb16a7c6868bd2e06